### PR TITLE
README.md: remove dead link to production-users.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ flannel is also widely used outside of kubernetes. When deployed outside of kube
 - [Running](Documentation/running.md)
 - [Troubleshooting](Documentation/troubleshooting.md)
 - [Projects integrating with flannel](Documentation/integrations.md)
-- [Production users](Documentation/production-users.md)
 
 ## Contact
 


### PR DESCRIPTION
## Description


this PR removes the 404 link from the top-level README;

linked file was removed with commit https://github.com/flannel-io/flannel/commit/af16a77280a2135a4d7d9acdc6c4e8d1d305b2b6 

I did a brief check and all other links in the readme are ok


## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
